### PR TITLE
Push to control plane catalog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,17 @@ workflows:
             tags:
               only: /^v.*/
 
+      - architect/push-to-app-catalog:
+          name: control-plane-app-catalog
+          context: "architect"
+          executor: "app-build-suite"
+          app_catalog: "control-plane-catalog"
+          app_catalog_test: "control-plane-test-catalog"
+          chart: "observability-bundle"
+          filters:
+            tags:
+              only: /^v.*/
+
       - architect/push-to-app-collection:
           name: aws-app-collection
           context: "architect"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Push to `control-plane-catalog`.
+
 ## [0.1.5] - 2022-12-14
 
 ### Changed


### PR DESCRIPTION
This PR:

- pushes to the control plane catalog so the app can get deployed on vintage MCs

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
