### PR TITLE
Upgrade prometheus-operator to 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `prometheus-operator-app` to 3.0.0.
+- Upgrade `prometheus-operator-crd` to 3.0.0.
+
 ## [0.1.8] - 2022-12-19
 
 ### Changed

--- a/helm/observability-bundle/Chart.yaml
+++ b/helm/observability-bundle/Chart.yaml
@@ -4,8 +4,9 @@ description: A Helm chart for Giant Swarm's collection of observability tools.
 home: https://github.com/giantswarm/observability-bundle
 sources:
   - https://github.com/giantswarm/observability-bundle
-version: 0.1.8
+version: 0.1.9
 annotations:
   application.giantswarm.io/app-type: bundle
   application.giantswarm.io/in-cluster-app: "true"
   application.giantswarm.io/team: atlas
+  config.giantswarm.io/version: 1.x.x

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -10,7 +10,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/prometheus-operator-crd
-    version: 2.0.1
+    version: 3.0.0
     # User values can be provided via a ConfigMap or Secret for each individual app
     userConfig: {}
     # a list of extraConfigs for the App,
@@ -27,7 +27,7 @@ apps:
     skipCRDs: true
     # used by renovate
     # repo: giantswarm/prometheus-operator-app
-    version: 2.1.2
+    version: 3.0.0
     userConfig:
       configMap:
         values: |


### PR DESCRIPTION
This PR:

* upgrades prometheus operator app and crd to 3.0.0

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
