### PR TITLE
Configure app dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+Add new app dependency mechanism (`app-operator.giantswarm.io/depends-on`) to the prometheus-operator-app and agent so they are not installed until the CRD app is deployed.
+
 ## [0.1.9] - 2023-01-16
 
 ### Changed

--- a/helm/observability-bundle/templates/apps.yaml
+++ b/helm/observability-bundle/templates/apps.yaml
@@ -5,6 +5,16 @@
 apiVersion: application.giantswarm.io/v1alpha1
 kind: App
 metadata:
+  {{- if .dependsOn }}
+  annotations:
+    {{- if hasPrefix "org-" $.Release.Namespace }}
+    # App is deployed in the org- namespace so the secret name is prefixed by the cluster-id
+    app-operator.giantswarm.io/depends-on: {{ printf "%s-%s" $.Values.clusterID .dependsOn -}}
+    {{- else }}
+    # App is deployed in the cluster-id namespace so prefix is unneeded
+    app-operator.giantswarm.io/depends-on: {{ .dependsOn -}}
+    {{- end }}
+  {{- end }}
   labels:
     {{- include "labels.common" $ | nindent 4 }}
   name: {{ $appName }}

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -22,6 +22,7 @@ apps:
     appName: prometheus-operator-app
     chartName: prometheus-operator-app
     catalog: giantswarm
+    dependsOn: prometheus-operator-crd
     enabled: true
     namespace: kube-system
     skipCRDs: true
@@ -124,6 +125,7 @@ apps:
     appName: prometheus-agent
     chartName: prometheus-agent
     catalog: giantswarm-playground
+    dependsOn: prometheus-operator-crd
     enabled: true
     namespace: kube-system
     # used by renovate


### PR DESCRIPTION
This PR:

* adds app dependency mechanism to prometheus operator app and agent so they do not install if the crds are not deployed (https://github.com/giantswarm/giantswarm/issues/25504)

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
