### PR TITLE
Upgrade prometheus-agent from to 0.1.7 to 0.2.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `prometheus-agent` from to 0.1.7 to 0.2.0.
+
 ## [0.1.9] - 2023-01-16
 
 ### Changed

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -128,7 +128,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/prometheus-agent-app
-    version: 0.1.7
+    version: 0.2.0
     # User values can be provided via a ConfigMap or Secret for each individual app
     # using the structure shown below.
     userConfig:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/25400

This PR:

* Upgrades `prometheus-agent` from to 0.1.7 to 0.2.0 (watchdog addition)

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
