### PR TITLE
prometheus-operator: drop unused high-cardinality apiserver metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- prometheus-operator: drop `apiserver_request_slo_duration_seconds_bucket` metrics from apiserver
+
 ## [0.2.0] - 2023-02-21
 
 ### Changed

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -49,6 +49,18 @@ apps:
                 # Add app label.
                 - targetLabel: app
                   replacement: kubernetes
+                metricRelabelings:
+                 # provided with original servicemonitor
+                - action: drop
+                  regex: apiserver_request_duration_seconds_bucket;(0.15|0.2|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2|3|3.5|4|4.5|6|7|8|9|15|25|40|50)
+                  sourceLabels:
+                  - __name__
+                  - le
+                # GS addition to reduce cardinality
+                - action: drop
+                  regex: apiserver_request_slo_duration_seconds_bucket
+                  sourceLabels:
+                  - __name__
             kubelet:
               enabled: false
             kubeControllerManager:

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -50,7 +50,7 @@ apps:
                 - targetLabel: app
                   replacement: kubernetes
                 metricRelabelings:
-                 # provided with original servicemonitor
+                  # Keep from upstream values (https://github.com/prometheus-community/helm-charts/blob/kube-prometheus-stack-44.4.1/charts/kube-prometheus-stack/values.yaml#L967)
                 - action: drop
                   regex: apiserver_request_duration_seconds_bucket;(0.15|0.2|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2|3|3.5|4|4.5|6|7|8|9|15|25|40|50)
                   sourceLabels:


### PR DESCRIPTION
This PR:

* drops `apiserver_request_slo_duration_seconds_bucket` metrics from apiserver target: high-cardinality and not used.

This metric is the one with the most metrics.
Example on `gauss`:
![image](https://user-images.githubusercontent.com/12008875/221539262-13127c45-fa95-4df9-9b80-a7214b0dcd8b.png)

There's no occurrence of this metric's name in the `prometheus-rules` or the `dashboards` repos.
So I think we can safely drop it.

Towards https://github.com/giantswarm/giantswarm/issues/25937

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
