### PR TITLE
Add promtail-app to bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `promtail-app` v1.0.1.
+
 ## [0.2.0] - 2023-02-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The observability bundle provides necessary components to enable observability c
 * prometheus-operator-crd
 * prometheus-operator-app
 * prometheus-agent
+* promtail-app
 
 
 ## Installing

--- a/helm/observability-bundle/values.schema.json
+++ b/helm/observability-bundle/values.schema.json
@@ -114,6 +114,35 @@
                             "type": "string"
                         }
                     }
+                },
+                "promtail-app": {
+                    "type": "object",
+                    "properties": {
+                        "appName": {
+                            "type": "string"
+                        },
+                        "catalog": {
+                            "type": "string"
+                        },
+                        "chartName": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "extraConfigs": {
+                            "type": "array"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "userConfig": {
+                            "type": "object"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         },

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -168,3 +168,19 @@ apps:
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example
     extraConfigs: {}
+
+  promtail-app:
+    appName: promtail-app
+    chartName: promtail-app
+    catalog: giantswarm
+    enabled: false
+    namespace: kube-system
+    # used by renovate
+    # repo: giantswarm/promtail-app
+    version: 1.0.1
+    # User values can be provided via a ConfigMap or Secret for each individual app
+    userConfig: {}
+    # a list of extraConfigs for the App,
+    # It can be secret or configmap
+    # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example
+    extraConfigs: []


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/2054

This PR:

* add `promtail-app` to the `observability-bundle` and disabled it by default

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [x] Test a deployment of the bundle on Vintage and verify `promtail-app` is not installed
- [x] Test a deployment of the bundle on CAPI and verify `promtail-app` is not installed
