### PR TITLE
Update prometheus-operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add new app dependency mechanism (`app-operator.giantswarm.io/depends-on`) to the prometheus-operator-app and agent so they are not installed until the CRD app is deployed.
 - prometheus-operator: drop `apiserver_request_slo_duration_seconds_bucket` metrics from apiserver
-- upgrade `prometheus-operator-app` and `prometheus-operator-crd` to 4.0.0
+- upgrade `prometheus-operator-app` to 4.0.1 and `prometheus-operator-crd` to 4.0.0
+- upgrade `prometheus-agent` to 0.3.0 to support chinese registry
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add new app dependency mechanism (`app-operator.giantswarm.io/depends-on`) to the prometheus-operator-app and agent so they are not installed until the CRD app is deployed.
 - prometheus-operator: drop `apiserver_request_slo_duration_seconds_bucket` metrics from apiserver
+- upgrade `prometheus-operator-app` and `prometheus-operator-crd` to 4.0.0
 
 ### Added
 

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -5,12 +5,12 @@ apps:
   prometheus-operator-crd:
     appName: prometheus-operator-crd
     chartName: prometheus-operator-crd
-    catalog: giantswarm
+    catalog: default
     enabled: true
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/prometheus-operator-crd
-    version: 3.0.0
+    version: 4.0.0
     # User values can be provided via a ConfigMap or Secret for each individual app
     userConfig: {}
     # a list of extraConfigs for the App,
@@ -21,30 +21,27 @@ apps:
   prometheus-operator-app:
     appName: prometheus-operator-app
     chartName: prometheus-operator-app
-    catalog: giantswarm
+    catalog: default
     dependsOn: prometheus-operator-crd
     enabled: true
     namespace: kube-system
     skipCRDs: true
     # used by renovate
     # repo: giantswarm/prometheus-operator-app
-    version: 3.0.0
+    version: 4.0.1
     userConfig:
       configMap:
         values: |
           prometheus-operator-app:
             defaultRules:
               create: false
-            global:
-              rbac:
-                create: true
-                pspEnabled: true
             alertmanager:
+              enabled: false
+            coreDns:
               enabled: false
             grafana:
               enabled: false
             kubeApiServer:
-              enabled: true
               serviceMonitor:
                 relabelings:
                 # Add app label.
@@ -62,10 +59,7 @@ apps:
                   regex: apiserver_request_slo_duration_seconds_bucket
                   sourceLabels:
                   - __name__
-            kubelet:
-              enabled: false
             kubeControllerManager:
-              enabled: true
               service:
                 port: 10257
                 targetPort: 10257
@@ -82,12 +76,13 @@ apps:
                 - sourceLabels:
                   - __meta_kubernetes_pod_node_name
                   targetLabel: node
-            coreDns:
-              enabled: false
             kubeEtcd:
               enabled: false
+            kubelet:
+              enabled: false
+            kubeProxy:
+              enabled: false
             kubeScheduler:
-              enabled: true
               service:
                 port: 10259
                 targetPort: 10259
@@ -104,10 +99,7 @@ apps:
                 - sourceLabels:
                   - __meta_kubernetes_pod_node_name
                   targetLabel: node
-            kubeProxy:
-              enabled: false
             prometheusOperator:
-              enabled: true
               serviceMonitor:
                 relabelings:
                 # Add app label.
@@ -136,13 +128,13 @@ apps:
   prometheus-agent:
     appName: prometheus-agent
     chartName: prometheus-agent
-    catalog: giantswarm-playground
+    catalog: default
     dependsOn: prometheus-operator-crd
     enabled: true
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/prometheus-agent-app
-    version: 0.2.0
+    version: 0.3.0
     # User values can be provided via a ConfigMap or Secret for each individual app
     # using the structure shown below.
     userConfig:

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "config:base",
-    ":reviewer(team:team-hydra)"
+    ":reviewer(team:team-atlas)"
   ],
   "labels": ["dependencies"],
   "dependencyDashboard": true,

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,9 @@
 {
   "extends": [
     "config:base",
-    ":reviewer(team:team-atlas)"
+    ":reviewer(team:team-hydra)"
   ],
-  "labels": ["dependencies", "renovate"],
+  "labels": ["dependencies"],
   "dependencyDashboard": true,
   "ignorePaths": [
     ".github/workflows/zz_generated.*",
@@ -13,6 +13,14 @@
     "architect",
     "zricethezav/gitleaks-action",
     "actions/setup-go"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^helm\\/.+\\/values\\.yaml$"],
+      "matchStrings": ["repo: (?<depName>.*)\n(\\s)*version: (?<currentValue>.*?)\n"],
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }
   ],
   "schedule": [ "after 6am on thursday" ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
     "config:base",
     ":reviewer(team:team-atlas)"
   ],
-  "labels": ["dependencies"],
+  "labels": ["dependencies", "renovate"],
   "dependencyDashboard": true,
   "ignorePaths": [
     ".github/workflows/zz_generated.*",


### PR DESCRIPTION
This PR:

* upgrades prometheus-operator-app and crd to 4.0.0. This enables exporters (i.e. service monitors for kubelet, coredns, kube-proxy and etcd). 
Waiting for a PMO PR

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
