### PR TITLE
Upgrade prometheus-agent-app to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `prometheus-agent-app` to 0.4.0.
+
 ## [0.4.0] - 2023-04-13
 
 ### Added

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -57,7 +57,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/prometheus-agent-app
-    version: 0.3.0
+    version: 0.4.0
     # User values can be provided via a ConfigMap or Secret for each individual app
     # using the structure shown below.
     userConfig:


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/26629

A new version of prometheus-agent has been released to fix the watchdog and the data lost.
We have to update the observability-bundle with this version.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
