### PR TITLE
Bump prometheus-agent-app to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `prometheus-agent-app` to 0.4.1.
+
 ## [0.4.1] - 2023-04-20
 
 ### Changed

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -57,7 +57,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/prometheus-agent-app
-    version: 0.4.0
+    version: 0.4.1
     # User values can be provided via a ConfigMap or Secret for each individual app
     # using the structure shown below.
     userConfig:


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/26674

Bump `prometheus-agent-app` to 0.4.1: fix preStop with removing the wal directory

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
