### PR TITLE
Revert name change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Remove cluster prefix to app name in _helpers.tpl
+
 ## [0.5.0] - 2023-05-10
 
 ### Changed

--- a/helm/observability-bundle/templates/_helpers.tpl
+++ b/helm/observability-bundle/templates/_helpers.tpl
@@ -17,7 +17,11 @@ Create chart name and version as used by the chart label.
 When apps are created in the org namespace add a cluster prefix.
 */}}
 {{- define "app.name" -}}
-{{- .app -}}
+{{- if hasPrefix "org-" .ns -}}
+{{- printf "%s-%s" .cluster .app -}}
+{{- else -}}
+{{- .app -}} for the rest (vintage MCs and WCs this will just be .app)
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/helm/observability-bundle/templates/_helpers.tpl
+++ b/helm/observability-bundle/templates/_helpers.tpl
@@ -17,11 +17,7 @@ Create chart name and version as used by the chart label.
 When apps are created in the org namespace add a cluster prefix.
 */}}
 {{- define "app.name" -}}
-{{- if ne .cluster .ns -}}
-{{- printf "%s-%s" .cluster .app -}}
-{{- else -}}
 {{- .app -}}
-{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
This PR:

towards https://github.com/giantswarm/giantswarm/issues/26932

Reverting the change which introduced the addition of cluster prefix into the app name as it's causing major issues on several installations.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
