### PR TITLE
Enable cilium for prometheus-operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add extra config for `prometheus-operator-app` to be able to enable cilium.
+
+### Changed
+
+- Upgrade `prometheus-operator-app` and `prometheus-operator-crd` to 5.1.0.
+
 ## [0.7.2] - 2023-07-13
 
 ### Changed

--- a/helm/observability-bundle/templates/prometheus-operator-extraconfig.yaml
+++ b/helm/observability-bundle/templates/prometheus-operator-extraconfig.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+data:
+  values: |
+    prometheus-operator-app:
+      defaultRules:
+        create: false
+      kubeProxy:
+        enabled: false
+      alertmanager:
+        enabled: false
+      grafana:
+        enabled: false
+      prometheus:
+        enabled: false
+      {{- if .Values.ciliumNetworkPolicy.enabled }}
+      prometheusOperator:
+        networkPolicy:
+          flavor: cilium
+          matchLabels:
+            app.kubernetes.io/instance: prometheus-operator-app
+            app.kubernetes.io/part-of: prometheus-operator-app
+            application.giantswarm.io/team: atlas
+      kube-state-metrics:
+        networkPolicy:
+          flavor: cilium
+      {{- end }}
+kind: ConfigMap
+metadata:
+  name: "{{ $.Values.clusterID }}-prometheus-operator"
+  namespace: "{{ $.Release.Namespace }}"

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -1,6 +1,9 @@
 clusterID: ""
 organization: ""
 
+ciliumNetworkPolicy:
+  enabled: false
+
 apps:
   prometheus-operator-crd:
     appName: prometheus-operator-crd
@@ -10,7 +13,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/prometheus-operator-crd
-    version: 5.0.0
+    version: 5.1.0
     # User values can be provided via a ConfigMap or Secret for each individual app
     userConfig: {}
     # a list of extraConfigs for the App,
@@ -28,25 +31,15 @@ apps:
     skipCRDs: true
     # used by renovate
     # repo: giantswarm/prometheus-operator-app
-    version: 5.0.7
-    userConfig:
-      configMap:
-        values: |
-          prometheus-operator-app:
-            defaultRules:
-              create: false
-            kubeProxy:
-              enabled: false
-            alertmanager:
-              enabled: false
-            grafana:
-              enabled: false
-            prometheus:
-              enabled: false
+    version: 5.1.0
+    userConfig: {}
     # a list of extraConfigs for the App,
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example
-    extraConfigs: []
+    extraConfigs:
+      - kind: configMap
+        name: "{{ $.Values.clusterID }}-prometheus-operator"
+        namespace: "{{ $.Release.Namespace }}"
 
   prometheus-agent:
     appName: prometheus-agent


### PR DESCRIPTION
This PR:

* ensures prometheus operator can be used with cilium https://github.com/giantswarm/giantswarm/issues/27646

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
