### PR TITLE
Upgrade prometheus agent app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `prometheus-agent` to 0.6.0.
+- Upgrade `prometheus-operator-app` and `prometheus-operator-crd` to 6.0.0.
+
 ## [0.7.5] - 2023-08-29
 
 ### Added

--- a/helm/observability-bundle/Chart.yaml
+++ b/helm/observability-bundle/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v2
 name: observability-bundle
 description: A Helm chart for Giant Swarm's collection of observability tools.
 home: https://github.com/giantswarm/observability-bundle
+kubeVersion: ">=1.19.0-0"
 sources:
   - https://github.com/giantswarm/observability-bundle
 version: 0.7.5

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -13,7 +13,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/prometheus-operator-crd
-    version: 5.1.0
+    version: 6.0.0
     # User values can be provided via a ConfigMap or Secret for each individual app
     userConfig: {}
     # a list of extraConfigs for the App,
@@ -31,7 +31,7 @@ apps:
     skipCRDs: true
     # used by renovate
     # repo: giantswarm/prometheus-operator-app
-    version: 5.2.0
+    version: 6.0.0
     userConfig: {}
     # a list of extraConfigs for the App,
     # It can be secret or configmap
@@ -50,42 +50,10 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/prometheus-agent-app
-    version: 0.5.4
+    version: 0.6.0
     # User values can be provided via a ConfigMap or Secret for each individual app
     # using the structure shown below.
-    userConfig:
-      configMap:
-        values: |
-          prometheus-agent:
-            serviceMonitorNamespaceSelector: {}
-            serviceMonitorSelector:
-              matchExpressions:
-                - key: "application.giantswarm.io/team"
-                  operator: "Exists"
-            podMonitorNamespaceSelector: {}
-            podMonitorSelector:
-              matchExpressions:
-                - key: "application.giantswarm.io/team"
-                  operator: "Exists"
-            serviceMonitor:
-              enabled: true
-              relabelings:
-              # Add app label.
-              - sourceLabels:
-                - __meta_kubernetes_pod_label_app_kubernetes_io_name
-                targetLabel: app
-              # Add instance label.
-              - sourceLabels:
-                - __meta_kubernetes_pod_label_app_kubernetes_io_instance
-                targetLabel: instance
-              # Add node label.
-              - sourceLabels:
-                - __meta_kubernetes_pod_node_name
-                targetLabel: node
-              # Add team label.
-              - sourceLabels:
-                - __meta_kubernetes_pod_label_application_giantswarm_io_team
-                targetLabel: team
+    userConfig: {}
     # a list of extraConfigs for the App,
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example


### PR DESCRIPTION
To be merged after https://github.com/giantswarm/prometheus-agent-app/pull/74 is released

This PR:

* upgrades prometheus-agent app to 0.6.0

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
