### PR TITLE
Upgrade Apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Upgrade `prometheus-agent` to 0.6.2.
+  - Upgrade `prometheus` to 2.47.0.
+- Upgrade `prometheus-operator-app` and `prometheus-operator-crd` to 6.1.0.
+
 ## [0.8.0] - 2023-09-04
 
 ### Changed

--- a/helm/observability-bundle/templates/promtail-extraconfig.yaml
+++ b/helm/observability-bundle/templates/promtail-extraconfig.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data:
+  values: |
+    ciliumNetworkPolicy:
+        enabled: {{ .Values.ciliumNetworkPolicy.enabled }}
+    {{ if not .Values.ciliumNetworkPolicy.enabled }}
+    promtail:
+      networkPolicy:
+        enabled: true
+    {{- end }}
+kind: ConfigMap
+metadata:
+  name: "{{ $.Values.clusterID }}-promtail-app-extraconfig"
+  namespace: "{{ $.Release.Namespace }}"

--- a/helm/observability-bundle/templates/promtail-extraconfig.yaml
+++ b/helm/observability-bundle/templates/promtail-extraconfig.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 data:
   values: |
     ciliumNetworkPolicy:
-        enabled: {{ .Values.ciliumNetworkPolicy.enabled }}
+      enabled: {{ .Values.ciliumNetworkPolicy.enabled }}
     {{ if not .Values.ciliumNetworkPolicy.enabled }}
     promtail:
       networkPolicy:

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -24,14 +24,14 @@ apps:
   prometheus-operator-app:
     appName: prometheus-operator-app
     chartName: prometheus-operator-app
-    catalog: default-test
+    catalog: default
     dependsOn: prometheus-operator-crd
     enabled: true
     namespace: kube-system
     skipCRDs: true
     # used by renovate
     # repo: giantswarm/prometheus-operator-app
-    version: 6.0.0-c8b899d4309c2983944d94474091fc2d953d7ca2
+    version: 6.1.0
     userConfig: {}
     # a list of extraConfigs for the App,
     # It can be secret or configmap

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -86,3 +86,6 @@ apps:
       - kind: configMap
         name: "{{ $.Values.clusterID }}-logging-config"
         namespace: "{{ $.Release.Namespace }}"
+      - kind: configMap
+        name: "{{ $.Values.clusterID }}-promtail-app-extraconfig"
+        namespace: "{{ $.Release.Namespace }}"

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -13,7 +13,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/prometheus-operator-crd
-    version: 6.0.0
+    version: 6.1.0
     # User values can be provided via a ConfigMap or Secret for each individual app
     userConfig: {}
     # a list of extraConfigs for the App,
@@ -24,14 +24,14 @@ apps:
   prometheus-operator-app:
     appName: prometheus-operator-app
     chartName: prometheus-operator-app
-    catalog: default
+    catalog: default-test
     dependsOn: prometheus-operator-crd
     enabled: true
     namespace: kube-system
     skipCRDs: true
     # used by renovate
     # repo: giantswarm/prometheus-operator-app
-    version: 6.0.0
+    version: 6.0.0-c8b899d4309c2983944d94474091fc2d953d7ca2
     userConfig: {}
     # a list of extraConfigs for the App,
     # It can be secret or configmap
@@ -50,7 +50,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/prometheus-agent-app
-    version: 0.6.0
+    version: 0.6.2
     # User values can be provided via a ConfigMap or Secret for each individual app
     # using the structure shown below.
     userConfig: {}


### PR DESCRIPTION
This PR:

* upgrades Prometheus operator and CRDS to 6.1.0 (prometheus operator 0.68.0) to fix scraping issues with the cilium network policy
* upgrades Prometheus Agent to 0.6.2 => Prometheus to 2.47.0

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
