### PR TITLE
Enable kube-proxy servicemonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Enable the `kube-proxy` servicemonitor.
+
 ## [0.8.2] - 2023-09-13
 
 ### Changed

--- a/helm/observability-bundle/templates/prometheus-operator-extraconfig.yaml
+++ b/helm/observability-bundle/templates/prometheus-operator-extraconfig.yaml
@@ -4,8 +4,6 @@ data:
     prometheus-operator-app:
       defaultRules:
         create: false
-      kubeProxy:
-        enabled: false
       alertmanager:
         enabled: false
       grafana:


### PR DESCRIPTION
This PR:

* enables the kube-proxy service monitor so we can ignore it in the list of targets from PMO

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
