### PR TITLE
Bump grafana-agent to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `grafana-agent` to 0.3.0.
+
 ## [0.9.1] - 2023-11-02
 
 ### Changed

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -105,7 +105,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/grafana-agent-app
-    version: 0.2.1
+    version: 0.3.0
     # User values can be provided via a ConfigMap or Secret for each individual app
     userConfig: {}
     # a list of extraConfigs for the App,


### PR DESCRIPTION
This PR:

* bump `grafana-agent` to 0.3.0.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
