### PR TITLE
Extend prometheus-operator-app timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Extend `prometheus-operator-app` timeout to avoid race condition with VPA causing the app to be stuck in `pending-install` state.
+
 ## [0.10.0] - 2023-11-08
 
 ### Changed

--- a/helm/observability-bundle/templates/apps.yaml
+++ b/helm/observability-bundle/templates/apps.yaml
@@ -31,9 +31,9 @@ spec:
   {{- end }}
   install:
     skipCRDs: {{.skipCRDs | default false }}
-    timeout: 10m
+    timeout: {{ .timeout | default "10m" }}
   upgrade: 
-    timeout: 10m
+    timeout: {{ .timeout | default "10m" }}
   kubeConfig:
     ## Vintage MCs do not have a kubeconfig secret
     {{- if eq $.Release.Namespace "giantswarm" }}

--- a/helm/observability-bundle/values.schema.json
+++ b/helm/observability-bundle/values.schema.json
@@ -5,6 +5,49 @@
         "apps": {
             "type": "object",
             "properties": {
+                "grafanaAgent": {
+                    "type": "object",
+                    "properties": {
+                        "appName": {
+                            "type": "string"
+                        },
+                        "catalog": {
+                            "type": "string"
+                        },
+                        "chartName": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "extraConfigs": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "kind": {
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "namespace": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "userConfig": {
+                            "type": "object"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "prometheus-agent": {
                     "type": "object",
                     "properties": {
@@ -91,6 +134,9 @@
                         },
                         "skipCRDs": {
                             "type": "boolean"
+                        },
+                        "timeout": {
+                            "type": "string"
                         },
                         "userConfig": {
                             "type": "object"

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -33,6 +33,7 @@ apps:
     enabled: true
     namespace: kube-system
     skipCRDs: true
+    timeout: 15m
     # used by renovate
     # repo: giantswarm/prometheus-operator-app
     version: 6.2.1


### PR DESCRIPTION
This PR:

* extends prometheus-operator-app timeout to avoid race conditions when installing

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
