### PR TITLE
Update kube-prometheus-stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Rename `promtail-app` to `promtail`
 - Enforce `Cilium Network Policy` by default.
 - Enforce `Pod Security Standard` by default.
-- Upgrade `kube-prometheus-stack` and `prometheus-operator-crd` to 8.0.0
+- Upgrade `kube-prometheus-stack` to 8.1.0 and `prometheus-operator-crd` to 8.0.0
 
 ## [0.10.1] - 2023-11-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- *!Breaking change*: Simplify configuration for the bundled apps
+  - Move all user configs from under `apps.appName.userConfig` from string to regular helm values to `appName.userConfig`
+  - Rename `prometheus-operator-app` to `kube-prometheus-stack`
+  - Rename `promtail-app` to `promtail`
+- Enforce `Cilium Network Policy` by default.
+- Enforce `Pod Security Standard` by default.
+- Upgrade `kube-prometheus-stack` and `prometheus-operator-crd` to 8.0.0
+
 ## [0.10.1] - 2023-11-15
 
 ### Fixed
@@ -30,15 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `grafana-agent-app` to `observability-bundle`.
-
-### Changed
-
-- *!Breaking change*: Simplify configuration for the bundled apps
-  - Move all user configs from under `apps.appName.userConfig` from string to regular helm values to `appName.userConfig`
-  - Rename `prometheus-operator-app` to `kube-prometheus-stack`
-  - Rename `promtail-app` to `promtail`
-- Enforce `Cilium Network Policy` by default.
-- Enforce `Pod Security Standard` by default.
 
 ## [0.8.9] - 2023-10-18
 

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -60,7 +60,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/prometheus-operator-crd
-    version: 6.1.0
+    version: 8.0.0
 
   kubePrometheusStack:
     appName: kube-prometheus-stack
@@ -73,7 +73,7 @@ apps:
     timeout: 15m
     # used by renovate
     # repo: giantswarm/kube-prometheus-stack
-    version: 7.0.0
+    version: 8.1.0
 
   prometheusAgent:
     appName: prometheus-agent


### PR DESCRIPTION
This PR:

* upgrades kube-prometheus-stack to 55.3.1

Tested in Gauss

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
