### PR TITLE
Add pss toggle back and upgrade prometheus-operator apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `kube-prometheus-stack` and `prometheus-operator-crd` to 9.0.0.
+- Add the `global.podSecurityStandards.enforced` value back to be able to work on CAPI WCs.
+
 ## [1.1.1] - 2024-01-30
 
 ### Changed

--- a/helm/observability-bundle/templates/observability-bundle-psp-override.yaml
+++ b/helm/observability-bundle/templates/observability-bundle-psp-override.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+data:
+  values: |
+    global:
+      rbac:
+        pspEnabled: {{ not .Values.global.podSecurityStandards.enforced }}
+    kube-prometheus-stack:
+      grafana:
+        rbac:
+          pspEnabled: {{ not .Values.global.podSecurityStandards.enforced }}
+      kube-state-metrics:
+        podSecurityPolicy:
+          enabled: {{ not .Values.global.podSecurityStandards.enforced }}
+      prometheus-node-exporter:
+        rbac:
+          pspEnabled: {{ not .Values.global.podSecurityStandards.enforced }}
+    prometheus-agent:
+      psp:
+        enabled: {{ not .Values.global.podSecurityStandards.enforced }}
+    promtail:
+      rbac:
+        pspEnabled: {{ not .Values.global.podSecurityStandards.enforced }}
+    # For grafana-agent
+    psp:
+      enabled: {{ not .Values.global.podSecurityStandards.enforced }}
+kind: ConfigMap
+metadata:
+  name: "{{ $.Values.clusterID }}-observability-bundle-psp-override"
+  namespace: "{{ $.Release.Namespace }}"

--- a/helm/observability-bundle/values.schema.json
+++ b/helm/observability-bundle/values.schema.json
@@ -33,6 +33,9 @@
                                     },
                                     "namespace": {
                                         "type": "string"
+                                    },
+                                    "priority": {
+                                        "type": "integer"
                                     }
                                 }
                             }
@@ -62,6 +65,26 @@
                         },
                         "enabled": {
                             "type": "boolean"
+                        },
+                        "extraConfigs": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "kind": {
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "namespace": {
+                                        "type": "string"
+                                    },
+                                    "priority": {
+                                        "type": "integer"
+                                    }
+                                }
+                            }
                         },
                         "namespace": {
                             "type": "string"
@@ -108,6 +131,9 @@
                                     },
                                     "namespace": {
                                         "type": "string"
+                                    },
+                                    "priority": {
+                                        "type": "integer"
                                     }
                                 }
                             }
@@ -171,6 +197,9 @@
                                     },
                                     "namespace": {
                                         "type": "string"
+                                    },
+                                    "priority": {
+                                        "type": "integer"
                                     }
                                 }
                             }
@@ -188,6 +217,19 @@
         "clusterID": {
             "type": "string"
         },
+        "global": {
+            "type": "object",
+            "properties": {
+                "podSecurityStandards": {
+                    "type": "object",
+                    "properties": {
+                        "enforced": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
         "organization": {
             "type": "string"
         },
@@ -203,19 +245,6 @@
                                 "values": {
                                     "type": "object",
                                     "properties": {
-                                        "global": {
-                                            "type": "object",
-                                            "properties": {
-                                                "rbac": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "pspEnabled": {
-                                                            "type": "boolean"
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
                                         "kube-prometheus-stack": {
                                             "type": "object",
                                             "properties": {
@@ -240,14 +269,6 @@
                                                     "properties": {
                                                         "enabled": {
                                                             "type": "boolean"
-                                                        },
-                                                        "rbac": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "pspEnabled": {
-                                                                    "type": "boolean"
-                                                                }
-                                                            }
                                                         }
                                                     }
                                                 },
@@ -261,14 +282,6 @@
                                                                     "type": "string"
                                                                 }
                                                             }
-                                                        },
-                                                        "podSecurityPolicy": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "enabled": {
-                                                                    "type": "boolean"
-                                                                }
-                                                            }
                                                         }
                                                     }
                                                 },
@@ -277,19 +290,6 @@
                                                     "properties": {
                                                         "enabled": {
                                                             "type": "boolean"
-                                                        }
-                                                    }
-                                                },
-                                                "prometheus-node-exporter": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "rbac": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "pspEnabled": {
-                                                                    "type": "boolean"
-                                                                }
-                                                            }
                                                         }
                                                     }
                                                 },
@@ -328,34 +328,6 @@
                         }
                     }
                 },
-                "prometheusAgent": {
-                    "type": "object",
-                    "properties": {
-                        "configMap": {
-                            "type": "object",
-                            "properties": {
-                                "values": {
-                                    "type": "object",
-                                    "properties": {
-                                        "prometheus-agent": {
-                                            "type": "object",
-                                            "properties": {
-                                                "psp": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "enabled": {
-                                                            "type": "boolean"
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
                 "promtail": {
                     "type": "object",
                     "properties": {
@@ -380,14 +352,6 @@
                                                     "type": "object",
                                                     "properties": {
                                                         "enabled": {
-                                                            "type": "boolean"
-                                                        }
-                                                    }
-                                                },
-                                                "rbac": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "pspEnabled": {
                                                             "type": "boolean"
                                                         }
                                                     }

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -1,13 +1,14 @@
 clusterID: ""
 organization: ""
 
+global:
+  podSecurityStandards:
+    enforced: false
+
 userConfig:
   kubePrometheusStack:
     configMap:
       values:
-        global:
-          rbac:
-            pspEnabled: false
         kube-prometheus-stack:
           defaultRules:
             create: false
@@ -15,16 +16,9 @@ userConfig:
             enabled: false
           grafana:
             enabled: false
-            rbac:
-              pspEnabled: false
           kube-state-metrics:
-            podSecurityPolicy:
-              enabled: false
             networkPolicy:
               flavor: cilium
-          prometheus-node-exporter:
-            rbac:
-              pspEnabled: false
           prometheus:
             enabled: false
           prometheusOperator:
@@ -34,20 +28,12 @@ userConfig:
                 app.kubernetes.io/instance: kube-prometheus-stack
                 app.kubernetes.io/part-of: kube-prometheus-stack
                 application.giantswarm.io/team: atlas
-  prometheusAgent:
-    configMap:
-      values:
-        prometheus-agent:
-          psp:
-            enabled: false
   promtail:
     configMap:
       values:
         ciliumNetworkPolicy:
           enabled: true
         promtail:
-          rbac:
-            pspEnabled: false
           networkPolicy:
             enabled: false
 
@@ -60,7 +46,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/prometheus-operator-crd
-    version: 8.0.0
+    version: 9.0.0
 
   kubePrometheusStack:
     appName: kube-prometheus-stack
@@ -73,7 +59,15 @@ apps:
     timeout: 15m
     # used by renovate
     # repo: giantswarm/kube-prometheus-stack
-    version: 8.1.3
+    version: 9.0.0
+    # a list of extraConfigs for the App,
+    # It can be secret or configmap
+    # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example
+    extraConfigs:
+      - kind: configMap
+        name: "{{ $.Values.clusterID }}-observability-bundle-psp-override"
+        namespace: "{{ $.Release.Namespace }}"
+        priority: 150
 
   prometheusAgent:
     appName: prometheus-agent
@@ -89,6 +83,10 @@ apps:
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example
     extraConfigs:
+      - kind: configMap
+        name: "{{ $.Values.clusterID }}-observability-bundle-psp-override"
+        namespace: "{{ $.Release.Namespace }}"
+        priority: 150
       - kind: secret
         name: "{{ $.Values.clusterID }}-remote-write-secret"
         namespace: "{{ $.Release.Namespace }}"
@@ -109,6 +107,10 @@ apps:
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example
     extraConfigs:
+      - kind: configMap
+        name: "{{ $.Values.clusterID }}-observability-bundle-psp-override"
+        namespace: "{{ $.Release.Namespace }}"
+        priority: 150
       - kind: secret
         name: "{{ $.Values.clusterID }}-logging-secret"
         namespace: "{{ $.Release.Namespace }}"
@@ -129,6 +131,10 @@ apps:
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example
     extraConfigs:
+      - kind: configMap
+        name: "{{ $.Values.clusterID }}-observability-bundle-psp-override"
+        namespace: "{{ $.Release.Namespace }}"
+        priority: 150
       - kind: configMap
         name: "{{ $.Values.clusterID }}-grafana-agent-config"
         namespace: "{{ $.Release.Namespace }}"


### PR DESCRIPTION
This PR:

* upgrades prometheus operator apps
* adds back pss toggle for capi WCs

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
