### PR TITLE
Add missing depends on annotation to promtail and grafana-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add dependency on `prometheus-operator-crd` to all apps.
+
 ## [1.2.0] - 2024-02-07
 
 ### Changed

--- a/helm/observability-bundle/values.schema.json
+++ b/helm/observability-bundle/values.schema.json
@@ -17,6 +17,9 @@
                         "chartName": {
                             "type": "string"
                         },
+                        "dependsOn": {
+                            "type": "string"
+                        },
                         "enabled": {
                             "type": "boolean"
                         },
@@ -179,6 +182,9 @@
                             "type": "string"
                         },
                         "chartName": {
+                            "type": "string"
+                        },
+                        "dependsOn": {
                             "type": "string"
                         },
                         "enabled": {

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -98,6 +98,7 @@ apps:
     appName: promtail
     chartName: promtail
     catalog: giantswarm
+    dependsOn: prometheus-operator-crd
     enabled: false
     namespace: kube-system
     # used by renovate
@@ -122,6 +123,7 @@ apps:
     appName: grafana-agent
     chartName: grafana-agent
     catalog: giantswarm
+    dependsOn: prometheus-operator-crd
     enabled: false
     namespace: kube-system
     # used by renovate


### PR DESCRIPTION
This PR:

* adds app dependency mechanism to promtail and grafana-agent

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.

This will avoid errors like 

```
$ kubectl get app -n $WCNS $WC-grafana-agent -o yaml
[...]
invalid manifest error: (unable to build kubernetes objects from release manifest: resource mapping not found for name: "grafana-agent" namespace: "" from "": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
```
