### PR TITLE
Bump promtail 1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `promtail` to 1.5.3.
+  - Set RAM limit to 2x requests
+
 ## [1.3.1] - 2024-03-12
 
 ### Changed
 
 - Upgrade `promtail` to 1.5.2.
   - Adjust CPU settings
-  - Set RAM limit to 2x requests
 
 ## [1.3.0] - 2024-03-06
 

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -103,7 +103,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/promtail-app
-    version: 1.5.2
+    version: 1.5.3
     # a list of extraConfigs for the App,
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example


### PR DESCRIPTION
This PR:

- bump promtail 1.5.3 (set memory limit to 256Mi)

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
