### PR TITLE
prometheus-operator: skip promql check for loki rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- prometheus-operator will not check promql syntax for prometheusRules that are labelled `application.giantswarm.io/prometheus-rule-kind: loki`
+
 ## [1.4.0] - 2024-07-03
 
 ### Changed

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -22,6 +22,13 @@ userConfig:
           prometheus:
             enabled: false
           prometheusOperator:
+            admissionWebhooks:
+              objectSelector:
+                matchExpressions:
+                  - key: application.giantswarm.io/prometheus-rule-kind
+                    operator: NotIn
+                    values:
+                      - loki
             networkPolicy:
               flavor: cilium
               matchLabels:


### PR DESCRIPTION
This PR:

* changes prometheus-operator prometheusRules validation to skip promql syntax check for prometheusRules that are labelled `application.giantswarm.io/prometheus-rule-kind: loki`

Towards https://github.com/giantswarm/roadmap/issues/3178

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
