### PR TITLE
add Alloy app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2024-07-03
+
 ### Changed
 
-- Upgrade `kube-prometheus-stack` to 10.2.0 and `prometheus-operator-crd` to 10.0.0. This upgrade mainly consists in:
-  - kube-prometheus-stack dependency chart upgraded from [56.21.2](https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-56.21.2) to [58.7.2](https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-58.7.2)
-  - prometheus upgrade from 2.50.1 to 2.52.0
-  - thanos ruler upgrade from 0.34.1 to 0.35.0
+- Upgrade `kube-prometheus-stack` to 11.0.0 and `prometheus-operator-crd` to 11.0.0. This upgrade mainly consists in:
+  - kube-prometheus-stack dependency chart upgraded from [56.21.2](https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-56.21.2) to [61.0.0](https://github.com/prometheus-community/helm-charts/releases/tag/kube-prometheus-stack-61.0.0)
+  - prometheus upgrade from 2.50.1 to [2.53.0](https://github.com/prometheus-community/helm-charts/releases/tag/prometheus-25.22.0)
+  - thanos ruler upgrade from 0.34.1 to [0.35.1](https://github.com/thanos-io/thanos/releases/tag/v0.35.1)
   - kube-state-metrics from 2.10.0 to 2.12.0
-  - prometheus-operator from 0.71.2 to 0.73.2 also adding Scrape Class support
+  - prometheus-operator from 0.71.2 [0.75.0](https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.75.0) - adding remoteWrite.proxyFromEnvironment and Scrape Class support
+  - prometheus-node-exporter upgraded from 1.8.0 to [1.8.1](https://github.com/prometheus/node_exporter/releases/tag/v1.8.1)
 - Upgrade `grafana-agent` from 0.4.3 to 0.4.4
   - This version enables the override the grafana agent `CiliumNetworkPolicy` egress and ingress sections.
 
@@ -384,7 +387,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `app.giantswarm.io` label group was changed to `application.giantswarm.io`
 
-[Unreleased]: https://github.com/giantswarm/observability-bundle/compare/v1.3.4...HEAD
+[Unreleased]: https://github.com/giantswarm/observability-bundle/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/giantswarm/observability-bundle/compare/v1.3.4...v1.4.0
 [1.3.4]: https://github.com/giantswarm/observability-bundle/compare/v1.3.3...v1.3.4
 [1.3.3]: https://github.com/giantswarm/observability-bundle/compare/v1.3.2...v1.3.3
 [1.3.2]: https://github.com/giantswarm/observability-bundle/compare/v1.3.1...v1.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `alloy` v0.2.0
+
 ## [1.4.0] - 2024-07-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `alloy` v0.3.0
+- Add `alloy` v0.3.0 as `alloy-logs`
 
 ### Changed
 

--- a/helm/observability-bundle/Chart.yaml
+++ b/helm/observability-bundle/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://s.giantswarm.io/app-icons/giantswarm/1/light.svg
 kubeVersion: ">=1.19.0-0"
 sources:
   - https://github.com/giantswarm/observability-bundle
-version: 1.3.4
+version: 1.4.0
 annotations:
   application.giantswarm.io/app-type: bundle
   application.giantswarm.io/in-cluster-app: "true"

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -38,6 +38,30 @@ userConfig:
             enabled: false
 
 apps:
+  alloy:
+    appName: alloy
+    chartName: alloy
+    catalog: giantswarm
+    enabled: false
+    namespace: kube-system
+    # used by renovate
+    # repo: giantswarm/alloy-app
+    version: 0.2.0
+    # a list of extraConfigs for the App,
+    # It can be secret or configmap
+    # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example
+    extraConfigs:
+      - kind: configMap
+        name: "{{ $.Values.clusterID }}-observability-bundle-psp-override"
+        namespace: "{{ $.Release.Namespace }}"
+        priority: 150
+      - kind: secret
+        name: "{{ $.Values.clusterID }}-logging-secret"
+        namespace: "{{ $.Release.Namespace }}"
+      - kind: configMap
+        name: "{{ $.Values.clusterID }}-logging-config"
+        namespace: "{{ $.Release.Namespace }}"
+
   prometheusOperatorCrd:
     appName: prometheus-operator-crd
     chartName: prometheus-operator-crd

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -41,12 +41,12 @@ apps:
   alloy:
     appName: alloy
     chartName: alloy
-    catalog: giantswarm
+    catalog: giantswarm-test
     enabled: false
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/alloy-app
-    version: 0.2.0
+    version: 0.2.0-7da03ca0646a8318fa08b4d130f913a902c2d05c
     # a list of extraConfigs for the App,
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -58,10 +58,6 @@ apps:
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example
     extraConfigs:
-      - kind: configMap
-        name: "{{ $.Values.clusterID }}-observability-bundle-psp-override"
-        namespace: "{{ $.Release.Namespace }}"
-        priority: 150
       - kind: secret
         name: "{{ $.Values.clusterID }}-logging-secret"
         namespace: "{{ $.Release.Namespace }}"

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -45,8 +45,8 @@ userConfig:
             enabled: false
 
 apps:
-  alloy:
-    appName: alloy
+  alloy-logs:
+    appName: alloy-logs
     chartName: alloy
     catalog: giantswarm
     enabled: false

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -41,12 +41,12 @@ apps:
   alloy:
     appName: alloy
     chartName: alloy
-    catalog: giantswarm-test
+    catalog: giantswarm
     enabled: false
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/alloy-app
-    version: 0.2.0-7da03ca0646a8318fa08b4d130f913a902c2d05c
+    version: 0.3.0
     # a list of extraConfigs for the App,
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3524

This PR adds Alloy application into the observability bundle for it to be used as a logging agent in place of Promtail.