### PR TITLE
rename alloy-logs to alloyLogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Rename `alloy-logs` app to camel case `alloyLogs`.
+
 ## [1.5.1] - 2024-07-19
 
 ### Changed

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -45,7 +45,7 @@ userConfig:
             enabled: false
 
 apps:
-  alloy-logs:
+  alloyLogs:
     appName: alloy-logs
     chartName: alloy
     catalog: giantswarm


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3524

The naming style of Alloy app in the observability bundle is wrong as we are using camel case values there.

```
$ k -n=org-giantswarm get cm golem-observability-bundle-logging-extraconfig -oyaml|bl -p
apiVersion: v1
data:
  values: |
    apps:
      alloy-logs:      <--- here
        enabled: false
      grafanaAgent:
        enabled: true
      promtail:
        enabled: true
kind: ConfigMap
metadata:
  name: golem-observability-bundle-logging-extraconfig
  namespace: org-giantswarm
```

This PR fixes this issue by renaming alloy-logs app to alloyLogs in the observability bundle applications.