### PR TITLE
add alloy-metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `alloy` v0.3.1 as `alloy-metrics`
+
 ## [1.5.2] - 2024-07-24
 
 ### Changed

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -68,12 +68,12 @@ apps:
   alloyMetrics:
     appName: alloy-metrics
     chartName: alloy
-    catalog: giantswarm
+    catalog: giantswarm-test
     enabled: false
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/alloy-app
-    version: 0.3.1
+    version: 0.3.1-01eb00bb1529813554f65c3bea245c0ffbcfd0d9
     # a list of extraConfigs for the App,
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -59,10 +59,10 @@ apps:
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example
     extraConfigs:
       - kind: secret
-        name: "{{ $.Values.clusterID }}-logging-secret"
+        name: "{{ $.Values.clusterID }}-monitoring"
         namespace: "{{ $.Release.Namespace }}"
       - kind: configMap
-        name: "{{ $.Values.clusterID }}-logging-config"
+        name: "{{ $.Values.clusterID }}-monitoring"
         namespace: "{{ $.Release.Namespace }}"
 
   alloyMetrics:

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -73,7 +73,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/alloy-app
-    version: 0.3.1-a694ae6ddad7d20193d6c42d712214d342a2e65c
+    version: 0.3.1-0ea7e6c9fea5fa4ce5aede8f9e20ea21448fe0fb
     # a list of extraConfigs for the App,
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -73,7 +73,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/alloy-app
-    version: 0.3.1-01eb00bb1529813554f65c3bea245c0ffbcfd0d9
+    version: 0.3.1-a694ae6ddad7d20193d6c42d712214d342a2e65c
     # a list of extraConfigs for the App,
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -73,7 +73,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/alloy-app
-    version: 0.3.1-b59f95cc8e975aa23bdd4ae55933d1b806fc91b4
+    version: 0.4.0
     # a list of extraConfigs for the App,
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -78,9 +78,6 @@ apps:
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example
     extraConfigs:
-      - kind: secret
-        name: "{{ $.Values.clusterID }}-monitoring-secret"
-        namespace: "{{ $.Release.Namespace }}"
       - kind: configMap
         name: "{{ $.Values.clusterID }}-monitoring-config"
         namespace: "{{ $.Release.Namespace }}"

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -78,6 +78,9 @@ apps:
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example
     extraConfigs:
+      - kind: secret
+        name: "{{ $.Values.clusterID }}-monitoring-secret"
+        namespace: "{{ $.Release.Namespace }}"
       - kind: configMap
         name: "{{ $.Values.clusterID }}-monitoring-config"
         namespace: "{{ $.Release.Namespace }}"

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -73,7 +73,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/alloy-app
-    version: 0.3.1-0ea7e6c9fea5fa4ce5aede8f9e20ea21448fe0fb
+    version: 0.3.1-b59f95cc8e975aa23bdd4ae55933d1b806fc91b4
     # a list of extraConfigs for the App,
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -65,6 +65,26 @@ apps:
         name: "{{ $.Values.clusterID }}-logging-config"
         namespace: "{{ $.Release.Namespace }}"
 
+  alloyMetrics:
+    appName: alloy-metrics
+    chartName: alloy
+    catalog: giantswarm
+    enabled: false
+    namespace: kube-system
+    # used by renovate
+    # repo: giantswarm/alloy-app
+    version: 0.3.1
+    # a list of extraConfigs for the App,
+    # It can be secret or configmap
+    # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example
+    extraConfigs:
+      - kind: secret
+        name: "{{ $.Values.clusterID }}-logging-secret"
+        namespace: "{{ $.Release.Namespace }}"
+      - kind: configMap
+        name: "{{ $.Values.clusterID }}-logging-config"
+        namespace: "{{ $.Release.Namespace }}"
+
   prometheusOperatorCrd:
     appName: prometheus-operator-crd
     chartName: prometheus-operator-crd

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -59,10 +59,10 @@ apps:
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example
     extraConfigs:
       - kind: secret
-        name: "{{ $.Values.clusterID }}-monitoring"
+        name: "{{ $.Values.clusterID }}-logging-secret"
         namespace: "{{ $.Release.Namespace }}"
       - kind: configMap
-        name: "{{ $.Values.clusterID }}-monitoring"
+        name: "{{ $.Values.clusterID }}-logging-config"
         namespace: "{{ $.Release.Namespace }}"
 
   alloyMetrics:
@@ -79,10 +79,10 @@ apps:
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example
     extraConfigs:
       - kind: secret
-        name: "{{ $.Values.clusterID }}-logging-secret"
+        name: "{{ $.Values.clusterID }}-monitoring-secret"
         namespace: "{{ $.Release.Namespace }}"
       - kind: configMap
-        name: "{{ $.Values.clusterID }}-logging-config"
+        name: "{{ $.Values.clusterID }}-monitoring-config"
         namespace: "{{ $.Release.Namespace }}"
 
   prometheusOperatorCrd:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3522

Add Alloy as alloy-metrics app in order to use it as a monitoring agent instead of Prometheus Agent.