### PR TITLE
Upgrade Alloy to 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Upgrade alloy-logs to allow passing PodLogs via helm chart values
+- Upgrade `alloyLogs` to allow passing PodLogs via helm chart values
 
 ## [1.6.2] - 2024-09-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade alloy-logs to allow passing PodLogs via helm chart values
+
 ## [1.6.2] - 2024-09-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Upgrade `alloyLogs` to v0.6.0
+- Upgrade `alloyLogs` to v0.6.1
   - Allow passing PodLogs via helm chart values
   - Upgrade to Alloy v1.4.2 which fixes a bug with component reload/evaluation and keeping Alloy up-to-date
   - Fixes an issue with CiliumNetworkPolicy preventing Alloy to run in clustering mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Upgrade `alloyLogs` to allow passing PodLogs via helm chart values
+- Upgrade `alloyLogs` to v0.6.0
+  - Allow passing PodLogs via helm chart values
+  - Upgrade to Alloy v1.4.2 which fixes a bug with component reload/evaluation and keeping Alloy up-to-date
+  - Fixes an issue with CiliumNetworkPolicy preventing Alloy to run in clustering mode
 
 ## [1.6.2] - 2024-09-17
 

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -48,7 +48,7 @@ apps:
   alloyLogs:
     appName: alloy-logs
     chartName: alloy
-    catalog: giantswarm-test
+    catalog: giantswarm
     enabled: false
     namespace: kube-system
     # used by renovate

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -53,7 +53,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/alloy-app
-    version: 0.6.0
+    version: 0.6.1
     # a list of extraConfigs for the App,
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example
@@ -73,7 +73,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/alloy-app
-    version: 0.6.0
+    version: 0.6.1
     # a list of extraConfigs for the App,
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -53,7 +53,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/alloy-app
-    version: 0.5.2-09cf6d8045346b9b0b903aa216893c73bce37152
+    version: 0.5.2-240aa62c9080137deb15d94ce5a64723157fa0ed
     # a list of extraConfigs for the App,
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -48,7 +48,7 @@ apps:
   alloyLogs:
     appName: alloy-logs
     chartName: alloy
-    catalog: giantswarm
+    catalog: giantswarm-test
     enabled: false
     namespace: kube-system
     # used by renovate

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -53,7 +53,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/alloy-app
-    version: 0.5.2-dfd4af5e2830c9f911def098073b3695a0ffe554
+    version: 0.5.2-c58d22ed32d1ce13f8639dcb8a5b1f7e0d6d4e60
     # a list of extraConfigs for the App,
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -53,7 +53,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/alloy-app
-    version: 0.4.1
+    version: 0.5.2-09cf6d8045346b9b0b903aa216893c73bce37152
     # a list of extraConfigs for the App,
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -53,7 +53,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/alloy-app
-    version: 0.5.2-c58d22ed32d1ce13f8639dcb8a5b1f7e0d6d4e60
+    version: 0.6.0
     # a list of extraConfigs for the App,
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -73,7 +73,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/alloy-app
-    version: 0.4.1
+    version: 0.6.0
     # a list of extraConfigs for the App,
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -53,7 +53,7 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/alloy-app
-    version: 0.5.2-240aa62c9080137deb15d94ce5a64723157fa0ed
+    version: 0.5.2-dfd4af5e2830c9f911def098073b3695a0ffe554
     # a list of extraConfigs for the App,
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3518

This PR upgrade Alloy to version 0.6.1, this brings the following changes:
- allow passing PodLogs via helm chart values
- upgrade to Alloy v1.4.2 which fixes a bug with component reload/evaluation and keeping Alloy up-to-date
- fixes an issue with CiliumNetworkPolicy preventing Alloy to run in clustering mode