### PR TITLE
Upgrade alloyLogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `alloyLogs` to v0.5.2-2981da813949183205f2c7091b8968a294f28fcf
+
 ## [1.6.2] - 2024-09-17
 
 ### Fixed

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -48,12 +48,12 @@ apps:
   alloyLogs:
     appName: alloy-logs
     chartName: alloy
-    catalog: giantswarm
+    catalog: giantswarm-test
     enabled: false
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/alloy-app
-    version: 0.4.1
+    version: 0.5.2-2981da813949183205f2c7091b8968a294f28fcf
     # a list of extraConfigs for the App,
     # It can be secret or configmap
     # https://github.com/giantswarm/rfc/tree/main/multi-layer-app-config#example


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3518

This PR upgrade alloyLogs in order to fix an issue with component not being properly evaluated when the config changes

This would for example result in the new list of namespaces not being taken into account when selecting pods with discovery.kubernetes component.

* Alloy v1.3.1 => v1.4.1
* Helm chart v0.7.0 => v0.9.0
* Breaking changes are not affecting our current usage, and are listed here https://github.com/giantswarm/alloy-app/blob/main/CHANGELOG.md#changed

Alloy upgrade PR https://github.com/giantswarm/alloy-app/pull/53