### PR TITLE
do not validate log based alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- prometheus-operator will not check promql syntax for prometheusRules that are labelled `observability.giantswarm.io/rule-type: logs`
+
 ## [1.10.0] - 2025-02-26
 
 ### Changed

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -29,7 +29,7 @@ userConfig:
                     operator: NotIn
                     values:
                       - loki
-                  - key: observability.giantswarm.io/rule-kind
+                  - key: observability.giantswarm.io/rule-type
                     operator: NotIn
                     values:
                       - logs

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -29,6 +29,10 @@ userConfig:
                     operator: NotIn
                     values:
                       - loki
+                  - key: observability.giantswarm.io/rule-kind
+                    operator: NotIn
+                    values:
+                      - logs
             networkPolicy:
               flavor: cilium
               matchLabels:


### PR DESCRIPTION
This PR:

* makes sure the prometheus-operator does not validate log-based alerts with the new annotation. Migration of our alerts will be done later because we need this prometheus-operator config to be deployed on all MCs before we can proceed

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
