### PR TITLE
add monitors ksm metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add KSM configurations for PodMonitors, ServiceMonitors, and PodLogs info metrics with tenant label extraction
+
 ## [2.4.0] - 2025-12-16
 
 ### Changed

--- a/helm/observability-bundle/ksm-configurations/grafana_podlogs_v1beta1.yaml
+++ b/helm/observability-bundle/ksm-configurations/grafana_podlogs_v1beta1.yaml
@@ -1,0 +1,29 @@
+rbac:
+  - apiGroups:
+      - loki.grafana.com
+    resources:
+      - podlogs
+    verbs: ["list", "watch"]
+
+resources:
+  - groupVersionKind:
+      group: loki.grafana.com
+      kind: PodLogs
+      version: v1beta1
+    metricNamePrefix: kube_podlogs
+    labelsFromPath:
+      name:
+        - metadata
+        - name
+      namespace:
+        - metadata
+        - namespace
+      tenant:
+        - metadata
+        - labels
+        - observability.giantswarm.io/tenant
+    metrics:
+      - name: info
+        help: Information about a PodLogs resource.
+        each:
+          type: Info

--- a/helm/observability-bundle/ksm-configurations/grafana_podlogs_v1beta1.yaml
+++ b/helm/observability-bundle/ksm-configurations/grafana_podlogs_v1beta1.yaml
@@ -1,29 +1,34 @@
 rbac:
   - apiGroups:
-      - loki.grafana.com
+      - monitoring.grafana.com
     resources:
       - podlogs
     verbs: ["list", "watch"]
 
 resources:
   - groupVersionKind:
-      group: loki.grafana.com
+      group: monitoring.grafana.com
       kind: PodLogs
-      version: v1beta1
+      version: v1alpha2
     metricNamePrefix: kube_podlogs
-    labelsFromPath:
-      name:
-        - metadata
-        - name
-      namespace:
-        - metadata
-        - namespace
-      tenant:
-        - metadata
-        - labels
-        - observability.giantswarm.io/tenant
     metrics:
       - name: info
         help: Information about a PodLogs resource.
         each:
           type: Info
+          info:
+            labelsFromPath:
+              name:
+                - metadata
+                - name
+              namespace:
+                - metadata
+                - namespace
+              tenant:
+                - metadata
+                - labels
+                - observability.giantswarm.io/tenant
+              team:
+                - metadata
+                - labels
+                - application.giantswarm.io/team

--- a/helm/observability-bundle/ksm-configurations/prometheus_podmonitor_v1.yaml
+++ b/helm/observability-bundle/ksm-configurations/prometheus_podmonitor_v1.yaml
@@ -11,19 +11,24 @@ resources:
       kind: PodMonitor
       version: v1
     metricNamePrefix: kube_podmonitor
-    labelsFromPath:
-      name:
-        - metadata
-        - name
-      namespace:
-        - metadata
-        - namespace
-      tenant:
-        - metadata
-        - labels
-        - observability.giantswarm.io/tenant
     metrics:
       - name: info
         help: Information about a PodMonitor.
         each:
           type: Info
+          info:
+            labelsFromPath:
+              name:
+                - metadata
+                - name
+              namespace:
+                - metadata
+                - namespace
+              tenant:
+                - metadata
+                - labels
+                - observability.giantswarm.io/tenant
+              team:
+                - metadata
+                - labels
+                - application.giantswarm.io/team

--- a/helm/observability-bundle/ksm-configurations/prometheus_podmonitor_v1.yaml
+++ b/helm/observability-bundle/ksm-configurations/prometheus_podmonitor_v1.yaml
@@ -1,0 +1,29 @@
+rbac:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - podmonitors
+    verbs: ["list", "watch"]
+
+resources:
+  - groupVersionKind:
+      group: monitoring.coreos.com
+      kind: PodMonitor
+      version: v1
+    metricNamePrefix: kube_podmonitor
+    labelsFromPath:
+      name:
+        - metadata
+        - name
+      namespace:
+        - metadata
+        - namespace
+      tenant:
+        - metadata
+        - labels
+        - observability.giantswarm.io/tenant
+    metrics:
+      - name: info
+        help: Information about a PodMonitor.
+        each:
+          type: Info

--- a/helm/observability-bundle/ksm-configurations/prometheus_servicemonitor_v1.yaml
+++ b/helm/observability-bundle/ksm-configurations/prometheus_servicemonitor_v1.yaml
@@ -11,19 +11,24 @@ resources:
       kind: ServiceMonitor
       version: v1
     metricNamePrefix: kube_servicemonitor
-    labelsFromPath:
-      name:
-        - metadata
-        - name
-      namespace:
-        - metadata
-        - namespace
-      tenant:
-        - metadata
-        - labels
-        - observability.giantswarm.io/tenant
     metrics:
       - name: info
         help: Information about a ServiceMonitor.
         each:
           type: Info
+          info:
+            labelsFromPath:
+              name:
+                - metadata
+                - name
+              namespace:
+                - metadata
+                - namespace
+              tenant:
+                - metadata
+                - labels
+                - observability.giantswarm.io/tenant
+              team:
+                - metadata
+                - labels
+                - application.giantswarm.io/team

--- a/helm/observability-bundle/ksm-configurations/prometheus_servicemonitor_v1.yaml
+++ b/helm/observability-bundle/ksm-configurations/prometheus_servicemonitor_v1.yaml
@@ -1,0 +1,29 @@
+rbac:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs: ["list", "watch"]
+
+resources:
+  - groupVersionKind:
+      group: monitoring.coreos.com
+      kind: ServiceMonitor
+      version: v1
+    metricNamePrefix: kube_servicemonitor
+    labelsFromPath:
+      name:
+        - metadata
+        - name
+      namespace:
+        - metadata
+        - namespace
+      tenant:
+        - metadata
+        - labels
+        - observability.giantswarm.io/tenant
+    metrics:
+      - name: info
+        help: Information about a ServiceMonitor.
+        each:
+          type: Info


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/4024

This PR:

Add KSM CustomResource definition to expose ServiceMonitor, PodMonitor and podlogs metrics, with the name, namespace, and tenant and team labels extracted from the observability.giantswarm.io/tenant and application.giantswarm.io/team labels. 

We need both the tenant and team labels to be able to figure out the tenant used until we fully migrate away from the legacy metric collection based on application.giantswarm.io/team and only rely on observability.giantswarm.io/tenant.

Note that the tenant label does is not set on podlogs so it is not visible.

This is deployed on graveler

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
