### PR TITLE
Deploy new alloy-podlogs-crds chart as part of the bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update dependency giantswarm/kube-prometheus-stack-app to v20.2.0
+- Update dependency giantswarm/kube-prometheus-stack-app to v20.2.0.
+- Add new `alloy-podlogs-crds` chart.
 
 ## [2.8.0] - 2026-03-04
 

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -79,6 +79,16 @@ apps:
         name: "{{ $.Values.clusterID }}-logging-config"
         namespace: "{{ $.Release.Namespace }}"
 
+  alloyPodLogsCrds:
+    appName: alloy-podlogs-crds
+    chartName: alloy-podlogs-crds
+    catalog: default-test
+    enabled: true
+    namespace: kube-system
+    # used by renovate
+    # repo: giantswarm/alloy-app
+    version: 0.17.1-7b7236dd1e1a98c1d6776306bbfb4d2ff79ee221
+
   alloyMetrics:
     appName: alloy-metrics
     chartName: alloy


### PR DESCRIPTION
Towards https://gigantic.slack.com/archives/CN9LXS96U/p1774264058346949

Add new `alloy-podlogs-crds` chart to the bundle that will install the `PodLogs` CR in the clusters.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
