### PR TITLE
fix(ksm): add cluster_type label to CAPI cluster metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add Backstage audience annotations.
 - Add KSM metrics for Envoy Gateway resources.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Backstage audience annotations.
+- Add managementCluster: "" as a top-level value (populated from the cluster chart via defaultValues)
+- Moves full KSM metricRelabelings ownership from kube-prometheus-stack-app into observability-bundle
+
 ### Changed
 
 - Update dependency giantswarm/kube-prometheus-stack-app to v20.2.0
@@ -22,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add Backstage audience annotations.
 - Add KSM metrics for Envoy Gateway resources.
 - Add `application.giantswarm.io/team` annotation from HelmReleases as label to KSM emitted metrics.
 

--- a/helm/observability-bundle/Chart.yaml
+++ b/helm/observability-bundle/Chart.yaml
@@ -8,6 +8,7 @@ sources:
   - https://github.com/giantswarm/observability-bundle
 version: 2.6.0
 annotations:
-  application.giantswarm.io/app-type: bundle
-  application.giantswarm.io/in-cluster-app: "true"
+  io.giantswarm.application.app-type: bundle
+  io.giantswarm.application.audience: all
+  io.giantswarm.application.managed: "true"
   io.giantswarm.application.team: atlas

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -1,4 +1,5 @@
 clusterID: ""
+managementCluster: ""
 organization: ""
 
 userConfig:
@@ -15,6 +16,66 @@ userConfig:
           kube-state-metrics:
             networkPolicy:
               flavor: cilium
+            prometheus:
+              monitor:
+                metricRelabelings:
+                  # GS addition to reduce cardinality
+                  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+                  - sourceLabels: [__name__]
+                    regex: kube_(.+_annotations|secret_type|pod_status_qos_class|pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas|.+_metadata_resource_version)
+                    action: drop
+                  # drop image_id label
+                  - action: labeldrop
+                    regex: image_id
+                  # GS addition for dashboards
+                  - sourceLabels: [label_topology_kubernetes_io_region]
+                    targetLabel: region
+                    replacement: ${1}
+                    action: replace
+                  - sourceLabels: [label_topology_kubernetes_io_zone]
+                    targetLabel: zone
+                    replacement: ${1}
+                    action: replace
+                  - action: labeldrop
+                    regex: label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone
+                  # Override with label for AWS clusters if exists.
+                  - sourceLabels: [label_giantswarm_io_machine_deployment]
+                    targetLabel: nodepool
+                    replacement: ${1}
+                    action: replace
+                  # Override with label for Azure clusters if exists.
+                  - sourceLabels: [label_giantswarm_io_machine_pool]
+                    targetLabel: nodepool
+                    replacement: ${1}
+                    action: replace
+                  # CAPI monitoring specific BEGIN
+                  # (see kube-state-metrics rules in https://github.com/giantswarm/observability-bundle/tree/main/helm/observability-bundle/ksm-configurations)
+                  - action: replace
+                    sourceLabels:
+                      - __name__
+                      - cluster_name
+                    regex: "^capi_.+;(.+)"
+                    replacement: "${1}"
+                    targetLabel: cluster_id
+                  # Use the `name` label as cluster name if the above fails
+                  - action: replace
+                    sourceLabels:
+                      - __name__
+                      - cluster_name
+                      - name
+                    regex: "^capi_.+;;(.+)"
+                    replacement: "${1}"
+                    targetLabel: cluster_id
+                  # CAPI monitoring specific END
+                  # Set cluster_type for CAPI cluster metrics based on whether the cluster is the management cluster
+                  - sourceLabels: [__name__]
+                    regex: "capi_cluster_.+"
+                    targetLabel: cluster_type
+                    replacement: workload_cluster
+                  - sourceLabels: [__name__, cluster_id]
+                    regex: "capi_cluster_.+;{{ $.Values.managementCluster }}"
+                    targetLabel: cluster_type
+                    replacement: management_cluster
           prometheus:
             enabled: false
           prometheusOperator:


### PR DESCRIPTION
## Summary

- Adds `managementCluster: ""` as a top-level value (populated from the cluster chart via `defaultValues`)
- Moves full KSM `metricRelabelings` ownership from `kube-prometheus-stack-app` into observability-bundle (see giantswarm/kube-prometheus-stack-app#525)
- Appends two new rules after the existing CAPI `cluster_id` mapping rules:
  - Default `cluster_type=workload_cluster` for all `capi_cluster_*` metrics
  - Override to `cluster_type=management_cluster` where `cluster_id` matches `managementCluster`

## Dependencies

- giantswarm/cluster#826 (must pass `managementCluster` via `defaultValues`)
- giantswarm/kube-prometheus-stack-app#525 (removes the rules now owned here)

Fixes: https://github.com/giantswarm/giantswarm/issues/35079