### PR TITLE
feat: honor extraConfigs priority in HelmRelease valuesFrom ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- HelmReleases: honor the App platform `priority` field (1-150, default 25) on `extraConfigs` entries. `spec.valuesFrom` now reproduces the App platform merge order — all configMaps before all secrets (a secret always overrides a configMap), each kind ordered by priority around the user-config layer — preserving the App CR merge semantics after the migration. ([giantswarm#36096](https://github.com/giantswarm/giantswarm/issues/36096))
+
 ## [3.0.0] - 2026-06-04
 
 ### Changed

--- a/helm/observability-bundle/templates/_helpers.tpl
+++ b/helm/observability-bundle/templates/_helpers.tpl
@@ -77,3 +77,53 @@ kube-prometheus-stack:
           {{- concat $ksmCustomResourcesSpec (default (list) ((((($ksmUserConfig).customResourceState).config).spec).resources)) | toYaml | nindent 12 }}
 {{- end -}}
 {{- end -}}
+
+{{- /*
+sortedValuesFrom — reproduce the App platform's config merge order as a single
+Flux `valuesFrom` list (Flux merges the list top-to-bottom, later wins).
+
+App platform (github.com/giantswarm/app/pkg/values) merges all configMap layers,
+then all secret layers, then the secret blob OVER the configMap blob — so a secret
+ALWAYS overrides a configMap regardless of priority. Within a kind, extraConfigs are
+ordered by `priority` (1-150, default 25) around the user-config slot (100); bundle
+sub-apps have no cluster-values layer. Equal-priority extras keep authored order; an
+extra at priority 100 precedes the user-config layer (band is half-open: p <= 100).
+
+Sort key `KIND_PRIORITY_SOURCE_INDEX`:
+  KIND   0=configMap 1=secret      (all configMaps before all secrets)
+  PRIOR  %03d                       (numeric order)
+  SOURCE 0=extraConfig 1=userConfig (extra precedes user layer at equal priority)
+  INDEX  %03d authored position     (stable tie-break)
+Returns a YAML array of {kind,name} dicts.
+
+Arg: dict with keys:
+  extraConfigs        list of {kind,name,priority}
+  userConfigMapName   name | ""   (slot 100, configMap)
+  userSecretName      name | ""   (slot 100, secret)
+  root                $ (for tpl-ing extraConfig names)
+*/ -}}
+{{- define "sortedValuesFrom" -}}
+{{- $keyed := dict -}}
+{{- $keys := list -}}
+{{- if .userConfigMapName -}}
+{{- $k := printf "0_%03d_1_000" 100 -}}
+{{- $keyed = set $keyed $k (dict "kind" "ConfigMap" "name" .userConfigMapName) -}}
+{{- $keys = append $keys $k -}}
+{{- end -}}
+{{- if .userSecretName -}}
+{{- $k := printf "1_%03d_1_000" 100 -}}
+{{- $keyed = set $keyed $k (dict "kind" "Secret" "name" .userSecretName) -}}
+{{- $keys = append $keys $k -}}
+{{- end -}}
+{{- range $i, $ec := (.extraConfigs | default list) -}}
+{{- $isSecret := eq (lower ($ec.kind | default "configMap")) "secret" -}}
+{{- $k := printf "%s_%03d_0_%03d" (ternary "1" "0" $isSecret) (int ($ec.priority | default 25)) $i -}}
+{{- $keyed = set $keyed $k (dict "kind" (ternary "Secret" "ConfigMap" $isSecret) "name" (tpl $ec.name $.root)) -}}
+{{- $keys = append $keys $k -}}
+{{- end -}}
+{{- $out := list -}}
+{{- range $k := sortAlpha $keys -}}
+{{- $out = append $out (get $keyed $k) -}}
+{{- end -}}
+{{- $out | toYaml -}}
+{{- end -}}

--- a/helm/observability-bundle/templates/helmreleases.yaml
+++ b/helm/observability-bundle/templates/helmreleases.yaml
@@ -53,34 +53,26 @@ spec:
     remediation:
       retries: -1
       remediateLastFailure: false
-  {{- $hasExtraConfigs := gt (len (.extraConfigs | default list)) 0 }}
-  {{- $hasUserConfigMap := false }}
-  {{- $hasUserSecret := false }}
+  {{- /* extraConfigs carry the App platform `priority` (1-150, default 25). App platform
+         merges all configMaps then all secrets (secret always overrides configMap), ordering
+         each kind by priority around the user-config slot (100). Flux merges valuesFrom in
+         list order, so emit a single list sorted to reproduce that — see the
+         `sortedValuesFrom` helper. */}}
+  {{- $extraConfigs := .extraConfigs | default list }}
+  {{- $userConfigMapName := "" }}
+  {{- $userSecretName := "" }}
   {{- if $.Values.userConfig }}
   {{- with (get $.Values.userConfig $key) }}
-  {{- if .configMap }}{{ $hasUserConfigMap = true }}{{ end }}
-  {{- if .secret }}{{ $hasUserSecret = true }}{{ end }}
+  {{- if .configMap }}{{ $userConfigMapName = printf "%s-user-values" $appName }}{{ end }}
+  {{- if .secret }}{{ $userSecretName = printf "%s-user-secrets" $appName }}{{ end }}
   {{- end }}
   {{- end }}
-  {{- if or $hasExtraConfigs $hasUserConfigMap $hasUserSecret }}
+  {{- $sorted := include "sortedValuesFrom" (dict "extraConfigs" $extraConfigs "userConfigMapName" $userConfigMapName "userSecretName" $userSecretName "root" $) | fromYamlArray }}
+  {{- if $sorted }}
   valuesFrom:
-  {{- range $extraConfig := (.extraConfigs | default list) }}
-  {{- $kind := $extraConfig.kind }}
-  {{- if eq $kind "configMap" }}{{ $kind = "ConfigMap" }}{{ else if eq $kind "secret" }}{{ $kind = "Secret" }}{{ end }}
-  - kind: {{ $kind }}
-    name: {{ tpl $extraConfig.name $ }}
-    valuesKey: values
-    optional: false
-  {{- end }}
-  {{- if $hasUserConfigMap }}
-  - kind: ConfigMap
-    name: {{ $appName }}-user-values
-    valuesKey: values
-    optional: false
-  {{- end }}
-  {{- if $hasUserSecret }}
-  - kind: Secret
-    name: {{ $appName }}-user-secrets
+  {{- range $entry := $sorted }}
+  - kind: {{ $entry.kind }}
+    name: {{ $entry.name }}
     valuesKey: values
     optional: false
   {{- end }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/36096

Companion to [cluster#909](https://github.com/giantswarm/cluster/pull/909) and [security-bundle#749](https://github.com/giantswarm/security-bundle/pull/749) — same fix for the observability-bundle sub-app HelmReleases.

## Problem

Sub-App CRs supported a `priority` field (1-150, default 25) on `extraConfigs` entries that controlled merge order. App platform (`github.com/giantswarm/app/pkg/values`) merges **all configMap layers, then all secret layers, then the secret blob over the configMap blob** — so a secret always overrides a configMap regardless of priority, and within each kind entries are ordered by priority. The HelmRelease template introduced in #368 emits `valuesFrom` in authored list order, so priorities are ignored and the two kinds are interleaved.

This is not hypothetical here: the shipped `alloyEvents` app declares a secret extraConfig followed by a configMap extraConfig, so today it renders `Secret → ConfigMap` — meaning the configMap overrides the secret, the opposite of App platform behaviour.

## Change

Add a `sortedValuesFrom` helper that emits a single `valuesFrom` list sorted on `KIND_PRIORITY_SOURCE_INDEX` (configMap < secret, then priority, then extra < user-config layer, then stable authored index). This reproduces the App platform merge order exactly. Bundle sub-apps have no cluster-values layer, so only the user-config slot (100) and the extra-config bands apply.

## Verification

- `alloyEvents` now renders `ConfigMap (events-logger-config) → Secret (events-logger-secret)` — secret correctly overrides configMap.
- Priority scenario (configMaps 10/120 + secret 40 + user CM/secret): renders `cm-low → user-values → cm-high` (configMaps) then `sec-low → user-secrets` (secrets).
- Whole chart renders cleanly.
- The keyed approach was verified live end-to-end in the migrate-apps test campaign (Round 75): a priority-40 secret correctly beats a priority-120 configMap, preserved across the App→HR migration.

## Note on aws-nth-bundle

The third bundle, aws-nth-bundle, needs **no** equivalent change — its sub-app HelmReleases use a fixed, chart-controlled `valuesFrom` list with no `extraConfigs`/`priority` mechanism, so there is nothing to reorder.