### PR TITLE
fix: update changelog with alloy-app version update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.0.1] - 2026-06-16
 
+### Changed
+
+- Update `alloy-app` to 0.21.0
+
 ## [3.0.0] - 2026-06-04
 
 ### Changed


### PR DESCRIPTION
This PR:

adds the missing changelog entry after bumping `alloy-app` version.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
