### PR TITLE
feat: Extract kube-state-metrics into a standalone app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Deploy `kube-state-metrics` as a standalone app (`kube-state-metrics-app` `1.6.0`) instead of bundling it inside `kube-prometheus-stack`.
+
+### Changed
+
+- Disable the `kube-state-metrics` subchart in `kube-prometheus-stack` and move its config (network policy, ServiceMonitor metric relabelings, custom-resource-state configs and RBAC) to the standalone app.
+- Re-point the `ksm.customResources` helper at the standalone `kube-state-metrics` app values.
+
 ## [3.0.1] - 2026-06-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Deploy `kube-state-metrics` as a standalone app (`kube-state-metrics-app` `1.6.0`) instead of bundling it inside `kube-prometheus-stack`.
+- Deploy `kube-state-metrics` as a standalone app (`kube-state-metrics-app` `0.2.0`) instead of bundling it inside `kube-prometheus-stack`.
 
 ### Changed
 

--- a/helm/observability-bundle/templates/_helpers.tpl
+++ b/helm/observability-bundle/templates/_helpers.tpl
@@ -61,19 +61,18 @@ This helper will merge the KSM custom resources configuration defined in the rel
   {{- $ksmCustomResourcesSpec = concat $ksmCustomResourcesSpec $componentConfig.resources -}}
 {{ end }}
 
-{{- $ksmUserConfig := default (dict) (index (default (dict) (index (default (dict) ((($.Values.userConfig).kubePrometheusStack).configMap).values) "kube-prometheus-stack")) "kube-state-metrics") -}}
+{{- $ksmUserConfig := default (dict) (index (default (dict) ((($.Values.userConfig).kubeStateMetrics).configMap).values) "kube-state-metrics") -}}
 
 {{- if gt (len $ksmCustomResourcesSpec) 0 -}}
-kube-prometheus-stack:
-  kube-state-metrics:
-    rbac:
-      extraRules:
-      {{- concat $ksmCustomResourcesRbac (default (list) ((($ksmUserConfig).rbac).extraRules)) | toYaml | nindent 8 }}
-    customResourceState:
-      enabled: true
-      config:
-        spec:
-          resources:
-          {{- concat $ksmCustomResourcesSpec (default (list) ((((($ksmUserConfig).customResourceState).config).spec).resources)) | toYaml | nindent 12 }}
+kube-state-metrics:
+  rbac:
+    extraRules:
+    {{- concat $ksmCustomResourcesRbac (default (list) ((($ksmUserConfig).rbac).extraRules)) | toYaml | nindent 6 }}
+  customResourceState:
+    enabled: true
+    config:
+      spec:
+        resources:
+        {{- concat $ksmCustomResourcesSpec (default (list) ((((($ksmUserConfig).customResourceState).config).spec).resources)) | toYaml | nindent 10 }}
 {{- end -}}
 {{- end -}}

--- a/helm/observability-bundle/templates/helmreleases.yaml
+++ b/helm/observability-bundle/templates/helmreleases.yaml
@@ -100,7 +100,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 data:
   values: |
-{{- if eq $key "kubePrometheusStack" }}
+{{- if eq $key "kubeStateMetrics" }}
   {{- (tpl (deepCopy .configMap.values | merge (include "ksm.customResources" $ | fromYaml) | toYaml | toString) $) | nindent 4 }}
 {{- else }}
   {{- (tpl (.configMap.values | toYaml | toString) $) | nindent 4 }}

--- a/helm/observability-bundle/values.schema.json
+++ b/helm/observability-bundle/values.schema.json
@@ -203,6 +203,38 @@
                             "type": "string"
                         }
                     }
+                },
+                "kubeStateMetrics": {
+                    "type": "object",
+                    "properties": {
+                        "appName": {
+                            "type": "string"
+                        },
+                        "catalog": {
+                            "type": "string"
+                        },
+                        "chartName": {
+                            "type": "string"
+                        },
+                        "dependsOn": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "extraConfigs": {
+                            "type": "array"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         },
@@ -334,6 +366,14 @@
                                     }
                                 }
                             }
+                        }
+                    }
+                },
+                "kubeStateMetrics": {
+                    "type": "object",
+                    "properties": {
+                        "configMap": {
+                            "type": "object"
                         }
                     }
                 }

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -236,5 +236,5 @@ apps:
     namespace: kube-system
     # used by renovate
     # repo: giantswarm/kube-state-metrics-app
-    version: 1.6.0
+    version: 0.2.0
     extraConfigs: []

--- a/helm/observability-bundle/values.yaml
+++ b/helm/observability-bundle/values.yaml
@@ -13,11 +13,54 @@ userConfig:
             enabled: false
           grafana:
             enabled: false
-          kube-state-metrics:
+          # kube-state-metrics is now deployed as a standalone app (see the
+          # `kubeStateMetrics` app entry and its userConfig below). Disable the
+          # copy bundled inside kube-prometheus-stack.
+          kubeStateMetrics:
+            enabled: false
+          prometheus:
+            enabled: false
+          prometheusOperator:
+            admissionWebhooks:
+              objectSelector:
+                matchExpressions:
+                  - key: application.giantswarm.io/prometheus-rule-kind
+                    operator: NotIn
+                    values:
+                      - loki
+                  - key: observability.giantswarm.io/rule-type
+                    operator: NotIn
+                    values:
+                      - logs
             networkPolicy:
               flavor: cilium
-            prometheus:
-              monitor:
+              matchLabels:
+                app.kubernetes.io/instance: kube-prometheus-stack
+                app.kubernetes.io/part-of: kube-prometheus-stack
+                application.giantswarm.io/team: atlas
+
+  # Config for the standalone kube-state-metrics app (extracted from
+  # kube-prometheus-stack). The CRS custom resources and rbac extraRules are
+  # injected on top of this via the `ksm.customResources` helper.
+  kubeStateMetrics:
+    configMap:
+      values:
+        kube-state-metrics:
+          networkPolicy:
+            flavor: cilium
+          rbac:
+            # Kept here so the ksm.customResources helper concatenates it with the
+            # custom-resource-state rules (the helper replaces the chart default).
+            extraRules:
+            - apiGroups: ["autoscaling.k8s.io"]
+              resources:
+                - verticalpodautoscalers
+              verbs: ["list", "watch"]
+          prometheus:
+            monitor:
+              # chart 7.x reads relabelings from the per-endpoint `http` block first,
+              # so the full list must live here (it overrides the app default).
+              http:
                 metricRelabelings:
                   # GS addition to reduce cardinality
                   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
@@ -76,26 +119,6 @@ userConfig:
                     regex: "capi_cluster_.+;{{ $.Values.managementCluster }}"
                     targetLabel: cluster_type
                     replacement: management_cluster
-          prometheus:
-            enabled: false
-          prometheusOperator:
-            admissionWebhooks:
-              objectSelector:
-                matchExpressions:
-                  - key: application.giantswarm.io/prometheus-rule-kind
-                    operator: NotIn
-                    values:
-                      - loki
-                  - key: observability.giantswarm.io/rule-type
-                    operator: NotIn
-                    values:
-                      - logs
-            networkPolicy:
-              flavor: cilium
-              matchLabels:
-                app.kubernetes.io/instance: kube-prometheus-stack
-                app.kubernetes.io/part-of: kube-prometheus-stack
-                application.giantswarm.io/team: atlas
 
 apps:
   alloyEvents:
@@ -201,4 +224,17 @@ apps:
     # used by renovate
     # repo: giantswarm/kube-prometheus-stack-app
     version: 21.0.0
+    extraConfigs: []
+
+  kubeStateMetrics:
+    appName: kube-state-metrics
+    chartName: kube-state-metrics
+    catalog: default
+    dependsOn:
+      - prometheus-operator-crd
+    enabled: true
+    namespace: kube-system
+    # used by renovate
+    # repo: giantswarm/kube-state-metrics-app
+    version: 1.6.0
     extraConfigs: []


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/35294

Stops bundling kube-state-metrics (KSM) inside `kube-prometheus-stack` and deploys it as the standalone `kube-state-metrics-app` instead, as part of moving KSM ownership to Tenet. KSM stays in the bundle — it just becomes its own HelmRelease.

Depends on a `kube-state-metrics-app` release containing https://github.com/giantswarm/kube-state-metrics-app/pull/98 (version pinned to `0.2.0` here — adjust to the actual released tag).

What changed:
- Add a `kubeStateMetrics` app (OCIRepository + HelmRelease) depending on `prometheus-operator-crd`.
- Set `kubeStateMetrics.enabled: false` in the `kube-prometheus-stack` userConfig so the embedded subchart is no longer deployed.
- Move the KSM config out of the `kube-prometheus-stack` userConfig into a new `kubeStateMetrics` userConfig: network policy (`cilium`), the full ServiceMonitor `metricRelabelings` (incl. the CAPI `cluster_id`/`cluster_type` rules that depend on `managementCluster`), and the VPA `rbac.extraRules`.
- Re-point the `ksm.customResources` helper to emit top-level `kube-state-metrics:` and read its user overrides from the new app; the helper still concatenates the 40 `ksm-configurations` custom-resource-state specs + RBAC.

Note: the relabelings are injected under `prometheus.monitor.http.metricRelabelings` because the standalone chart (KSM `7.x`) reads the per-endpoint `http` block first; injecting at the top level would be silently overridden by the app's defaults.

Verified `helm template` + `helm lint`: the standalone HelmRelease renders with the CRS specs, the concatenated RBAC (CRS + VPA), cilium network policy, and the CAPI relabelings with `managementCluster` templated; the `kube-prometheus-stack` ConfigMap no longer carries any KSM config and has `kubeStateMetrics.enabled: false`.

## Upgrade / transition (existing customer clusters)

The upgrade replaces the embedded KSM with the standalone app. Metric continuity is preserved: `job="kube-state-metrics"` (ServiceMonitor `jobLabel: app.kubernetes.io/name`) and `app="kube-state-metrics"` are identical before and after, and the workload/CRS metrics (`kube_*`, `capi_*`, incl. `cluster_id`/`cluster_type`/`nodepool`/`region`/`zone`/`node`) keep the same labels because the relabelings + CRS config are carried over verbatim. Only KSM's own scrape-target labels change (`instance`/`pod`/`service`/`container`), affecting KSM-health panels only. Old resources are named `kube-prometheus-stack-kube-state-metrics-*` and new ones `kube-state-metrics-*`, so there is no ownership conflict — Helm removes the old set and creates the new set.

Verify before un-drafting / rolling out:
- **alloy-metrics ServiceMonitor discovery** — confirm the new `kube-state-metrics` ServiceMonitor is scraped on a test MC + WC (no `release=kube-prometheus-stack` selector is configured in this repo, but the alloy scrape config lives outside it). If discovery were ever filtered by such a label, KSM metrics would silently disappear.
- **Customer/MC userConfig overrides** — any cluster overriding `kube-prometheus-stack.kube-state-metrics.*` must move those overrides to the new `kubeStateMetrics` key; otherwise they sit under a disabled subchart and are silently ignored.
- **Transient cutover blip** — the two HelmReleases reconcile independently, so a short gap or a brief overlap (both pods scraped → instance-agnostic queries like `sum(kube_pod_info)` double-count) is possible for a scrape interval or two. Usually absorbed by alert `for:` windows; validate capacity/quota-style alerts on a test cluster.
