### PR TITLE
feat(ksm): add ListenerSet and ReferenceGrant, bump Gateway API to v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add KSM metrics for Gateway API `ListenerSet` and `ReferenceGrant` resources.
+
+### Changed
+
+- Update Gateway API KSM configs to `v1` for `Gateway`, `GatewayClass`, `HTTPRoute`, `GRPCRoute`, `TLSRoute` and `BackendTLSPolicy`.
+
 ## [3.2.0] - 2026-06-29
 
 ### Changed

--- a/helm/observability-bundle/ksm-configurations/gateway_networking_k8s_io.yaml
+++ b/helm/observability-bundle/ksm-configurations/gateway_networking_k8s_io.yaml
@@ -2,7 +2,7 @@ resources:
   - groupVersionKind:
       group: gateway.networking.k8s.io
       kind: "Gateway"
-      version: "v1beta1"
+      version: "v1"
     metricNamePrefix: gatewayapi_gateway
     labelsFromPath:
       name:
@@ -75,7 +75,7 @@ resources:
   - groupVersionKind:
       group: gateway.networking.k8s.io
       kind: "GatewayClass"
-      version: "v1beta1"
+      version: "v1"
     metricNamePrefix: gatewayapi_gatewayclass
     labelsFromPath:
       name:
@@ -122,7 +122,7 @@ resources:
   - groupVersionKind:
       group: gateway.networking.k8s.io
       kind: "HTTPRoute"
-      version: "v1beta1"
+      version: "v1"
     metricNamePrefix: gatewayapi_httproute
     labelsFromPath:
       name:
@@ -183,7 +183,7 @@ resources:
   - groupVersionKind:
       group: gateway.networking.k8s.io
       kind: "GRPCRoute"
-      version: "v1alpha2"
+      version: "v1"
     metricNamePrefix: gatewayapi_grpcroute
     labelsFromPath:
       name:
@@ -297,7 +297,7 @@ resources:
   - groupVersionKind:
       group: gateway.networking.k8s.io
       kind: "TLSRoute"
-      version: "v1alpha2"
+      version: "v1"
     metricNamePrefix: gatewayapi_tlsroute
     labelsFromPath:
       name:
@@ -411,7 +411,7 @@ resources:
   - groupVersionKind:
       group: gateway.networking.k8s.io
       kind: "BackendTLSPolicy"
-      version: "v1alpha2"
+      version: "v1"
     metricNamePrefix: gatewayapi_backendtlspolicy
     labelsFromPath:
       name:
@@ -445,6 +445,120 @@ resources:
               target_kind: ["kind"]
               target_name: ["name"]
               target_namespace: ["namespace"]
+  - groupVersionKind:
+      group: gateway.networking.k8s.io
+      kind: "ListenerSet"
+      version: "v1"
+    metricNamePrefix: gatewayapi_listenerset
+    labelsFromPath:
+      name:
+        - metadata
+        - name
+      namespace:
+        - metadata
+        - namespace
+    metrics:
+      - name: "created"
+        help: "created timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, creationTimestamp]
+      - name: "deleted"
+        help: "deletion timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, deletionTimestamp]
+            nilIsZero: true
+      - name: "parent_info"
+        help: "Parent reference that the listenerset is attached to"
+        each:
+          type: Info
+          info:
+            path: [spec, parentRef]
+            labelsFromPath:
+              parent_group: ["group"]
+              parent_kind: ["kind"]
+              parent_name: ["name"]
+              parent_namespace: ["namespace"]
+      - name: "listener_info"
+        help: "ListenerSet listener information"
+        each:
+          type: Info
+          info:
+            path: [spec, listeners]
+            labelsFromPath:
+              listener_name: ["name"]
+              port: ["port"]
+              protocol: ["protocol"]
+              hostname: ["hostname"]
+              tls_mode: ["tls", "mode"]
+              allowed_routes_namespaces_from: ["allowedRoutes", "namespaces", "from"]
+      - name: "status"
+        help: "status condition"
+        each:
+          type: Gauge
+          gauge:
+            path: [status, conditions]
+            labelsFromPath:
+              type: ["type"]
+            valueFrom: ["status"]
+      - name: "status_listener_attached_routes"
+        help: "Number of attached routes for a listener"
+        each:
+          type: Gauge
+          gauge:
+            path: [status, listeners]
+            labelsFromPath:
+              listener_name: ["name"]
+            valueFrom: ["attachedRoutes"]
+  - groupVersionKind:
+      group: gateway.networking.k8s.io
+      kind: "ReferenceGrant"
+      version: "v1"
+    metricNamePrefix: gatewayapi_referencegrant
+    labelsFromPath:
+      name:
+        - metadata
+        - name
+      namespace:
+        - metadata
+        - namespace
+    metrics:
+      - name: "created"
+        help: "created timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, creationTimestamp]
+      - name: "deleted"
+        help: "deletion timestamp"
+        each:
+          type: Gauge
+          gauge:
+            path: [metadata, deletionTimestamp]
+            nilIsZero: true
+      - name: "from_info"
+        help: "Resources that are allowed to reference across namespaces"
+        each:
+          type: Info
+          info:
+            path: [spec, from]
+            labelsFromPath:
+              from_group: ["group"]
+              from_kind: ["kind"]
+              from_namespace: ["namespace"]
+      - name: "to_info"
+        help: "Resources that may be referenced"
+        each:
+          type: Info
+          info:
+            path: [spec, to]
+            labelsFromPath:
+              to_group: ["group"]
+              to_kind: ["kind"]
+              to_name: ["name"]
 rbac:
   - apiGroups:
       - gateway.networking.k8s.io
@@ -457,6 +571,8 @@ rbac:
       - tlsroutes
       - udproutes
       - backendtlspolicies
+      - listenersets
+      - referencegrants
     verbs:
       - list
       - watch


### PR DESCRIPTION
## What

Update the Gateway API KSM configurations to match the CRD versions served in the cluster and cover two additional resources.

### Changed

- Bump KSM configs to `v1` for `Gateway`, `GatewayClass`, `HTTPRoute`, `GRPCRoute`, `TLSRoute` and `BackendTLSPolicy` (verified against the served/storage versions).
- `TCPRoute` and `UDPRoute` stay at `v1alpha2` since they are not installed here and upstream Gateway API still only serves them at `v1alpha2`.

### Added

- KSM metrics for the `ListenerSet` resource (`v1`): timestamps, parent reference, listener info, status conditions and attached routes.
- KSM metrics for the `ReferenceGrant` resource (`v1`): timestamps, `from` and `to` reference info.
- `listenersets` and `referencegrants` added to the RBAC list/watch rule.

## Notes

`TLSRoute` at `v1` is ahead of stock upstream Gateway API (still experimental `v1alpha2`). This matches the Envoy Gateway environment targeted here. If the bundle ships to clusters running the standard channel, `TLSRoute` may still be `v1alpha2` there.
